### PR TITLE
encode wasm metadata on CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,8 +8,13 @@ on:
 
 env:
   IMAGE_NAME: ${{ github.repository }}
-  COMPONENT_NAME: sample-wasi-http-rust
   CARGO_COMPONENT_VERSION: "0.16.0"
+  # TODO: These can be removed once https://github.com/bytecodealliance/cargo-component/pull/372 is merged
+  COMPONENT_NAME: sample-wasi-http-rust
+  COMPONENT_DESCRIPTION: "A sample WASI HTTP component written in Rust"
+  COMPONENT_SOURCE: "https://github.com/bytecodealliance/sample-wasi-http-rust"
+  COMPONENT_HOMEPAGE: "https://github.com/bytecodealliance/sample-wasi-http-rust"
+  COMPONENT_LICENSES: "Apache-2.0 WITH LLVM-exception"
 
 jobs:
   publish:
@@ -76,6 +81,10 @@ jobs:
           file: target/wasm32-wasip1/release/rust_wasi_hello.wasm
           oci-reference-without-tag: ghcr.io/${{ env.IMAGE_NAME }}/${{ env.COMPONENT_NAME }}
           version: ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+          description: ${{ env.COMPONENT_DESCRIPTION }}
+          source: ${{ env.COMPONENT_SOURCE }}
+          homepage: ${{ env.COMPONENT_HOMEPAGE }}
+          licenses: ${{ env.COMPONENT_LICENSES }}
 
       - name: Sign the wasm component
         if: github.event_name != 'workflow_dispatch'


### PR DESCRIPTION
This adds the right metadata to the component on CI. Once https://github.com/bytecodealliance/cargo-component/pull/372 lands we can remove the manual encoding. Thanks!