### PR TITLE
Publish a `:latest` tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Normalize COMPONENT_NAME and Append .wasm
         run: echo "COMPONENT_NAME_UNDERSCORED=${COMPONENT_NAME//-/_}.wasm" >> $GITHUB_ENV
 
-      - name: Publish to GitHub Container Registry
+      - name: Publish `:<version>` to GitHub Container Registry
         if: github.event_name != 'workflow_dispatch'
         id: publish
         uses: bytecodealliance/wkg-github-action@v5
@@ -87,6 +87,19 @@ jobs:
           file: target/wasm32-wasip1/release/${{ env.COMPONENT_NAME_UNDERSCORED }}
           oci-reference-without-tag: ghcr.io/${{ env.IMAGE_NAME }}/${{ env.COMPONENT_NAME }}
           version: ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+          description: ${{ env.COMPONENT_DESCRIPTION }}
+          source: ${{ env.COMPONENT_SOURCE }}
+          homepage: ${{ env.COMPONENT_HOMEPAGE }}
+          licenses: ${{ env.COMPONENT_LICENSES }}
+
+      - name: Publish `:latest` release to GitHub Container Registry
+        if: github.event_name != 'workflow_dispatch'
+        id: publish
+        uses: bytecodealliance/wkg-github-action@v5
+        with:
+          file: target/wasm32-wasip1/release/${{ env.COMPONENT_NAME_UNDERSCORED }}
+          oci-reference-without-tag: ghcr.io/${{ env.IMAGE_NAME }}/${{ env.COMPONENT_NAME }}
+          version: latest
           description: ${{ env.COMPONENT_DESCRIPTION }}
           source: ${{ env.COMPONENT_SOURCE }}
           homepage: ${{ env.COMPONENT_HOMEPAGE }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Publish `:<version>` to GitHub Container Registry
         if: github.event_name != 'workflow_dispatch'
-        id: publish
+        id: publish_versioned
         uses: bytecodealliance/wkg-github-action@v5
         with:
           file: target/wasm32-wasip1/release/${{ env.COMPONENT_NAME_UNDERSCORED }}
@@ -92,9 +92,13 @@ jobs:
           homepage: ${{ env.COMPONENT_HOMEPAGE }}
           licenses: ${{ env.COMPONENT_LICENSES }}
 
+      - name: Sign the versioned wasm component
+        if: github.event_name != 'workflow_dispatch'
+        run: cosign sign --yes ghcr.io/${{ env.IMAGE_NAME }}/${{ env.COMPONENT_NAME }}@${{ steps.publish_versioned.outputs.digest }}
+
       - name: Publish `:latest` release to GitHub Container Registry
         if: github.event_name != 'workflow_dispatch'
-        id: publish
+        id: publish_latest
         uses: bytecodealliance/wkg-github-action@v5
         with:
           file: target/wasm32-wasip1/release/${{ env.COMPONENT_NAME_UNDERSCORED }}
@@ -105,6 +109,7 @@ jobs:
           homepage: ${{ env.COMPONENT_HOMEPAGE }}
           licenses: ${{ env.COMPONENT_LICENSES }}
 
-      - name: Sign the wasm component
+      - name: Sign the latest wasm component
         if: github.event_name != 'workflow_dispatch'
-        run: cosign sign --yes ghcr.io/${{ env.IMAGE_NAME }}/${{ env.COMPONENT_NAME }}@${{ steps.publish.outputs.digest }}
+        run: cosign sign --yes ghcr.io/${{ env.IMAGE_NAME }}/${{ env.COMPONENT_NAME }}@${{ steps.publish_latest.outputs.digest }}
+


### PR DESCRIPTION
This is a follow-up to #51, fixing the second half of the fetch instructions. We currently don't publish a `:latest` tag while we should, and this should fix that. Thanks!