### PR TITLE
Add link to the JS sibling sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ on the pull + serve pattern we've shown here.
 
 ## See Also
 
-**Hosts**
-- [sample-wasi-http-aks-wasmcloud](https://github.com/yoshuawuyts/sample-wasi-http-aks-wasmcloud) - A `wasi:http` example host environment running on AKS using the WasmCloud runtime
+- [sample-wasi-http-js](https://github.com/bytecodealliance/sample-wasi-http-js) An example `wasi:http` server component written in JavaScript.
 
 ## License
 


### PR DESCRIPTION
This links to the new JS `wasi:http` sample and removes links to samples from outside the BA (in this case: my WasmCloud sample). We probably do still want to link to external projects, but probably keep a list for them in the central docs. @kate-goldenring do we have a place in the docs that links to the `wasi:http` samples yet?